### PR TITLE
dont run if triggered by merge queue

### DIFF
--- a/.github/workflows/check_cla.yml
+++ b/.github/workflows/check_cla.yml
@@ -19,7 +19,7 @@ jobs:
   check-membership:
     name: Check Membership
     runs-on: ubuntu-latest
-    if: ${{ github.event.pull_request.user.login != 'dependabot[bot]' && github.event.pull_request.user.login != 'github-actions[bot]' && github.event.label.name == 'merge_group' }}
+    if: ${{ github.event.pull_request.user.login != 'dependabot[bot]' && github.event.pull_request.user.login != 'github-actions[bot]' && github.event.label.name != 'merge_group' }}
     outputs:
       is_member: ${{ steps.check-membership.outputs.is_member}}
     steps:

--- a/.github/workflows/check_cla.yml
+++ b/.github/workflows/check_cla.yml
@@ -19,7 +19,8 @@ jobs:
   check-membership:
     name: Check Membership
     runs-on: ubuntu-latest
-    if: ${{ github.event.pull_request.user.login != 'dependabot[bot]' && github.event.pull_request.user.login != 'github-actions[bot]' && github.event.label.name != 'merge_group' }}
+    # Dont run this workflow if it was triggered by one of these bots
+    if: contains(fromJson('["dependabot[bot]", "github-actions[bot]", "github-merge-queue[bot]"]'), github.actor) == false
     outputs:
       is_member: ${{ steps.check-membership.outputs.is_member}}
     steps:

--- a/.github/workflows/check_cla.yml
+++ b/.github/workflows/check_cla.yml
@@ -19,7 +19,7 @@ jobs:
   check-membership:
     name: Check Membership
     runs-on: ubuntu-latest
-    if: ${{ github.event.pull_request.user.login != 'dependabot[bot]' && github.event.pull_request.user.login != 'github-actions[bot]' }} 
+    if: ${{ github.event.pull_request.user.login != 'dependabot[bot]' && github.event.pull_request.user.login != 'github-actions[bot]' && github.event.label.name == 'merge_group' }}
     outputs:
       is_member: ${{ steps.check-membership.outputs.is_member}}
     steps:

--- a/reusable_workflows/check_membership/check_membership/action.yml
+++ b/reusable_workflows/check_membership/check_membership/action.yml
@@ -10,7 +10,7 @@ inputs:
     required: true
   user:
     description: "The username"
-    default: ${{ github.event.pull_request.user.login }}
+    default: ${{ github.actor }}
     required: false
 outputs:
   is_member:

--- a/reusable_workflows/check_membership/check_membership/action.yml
+++ b/reusable_workflows/check_membership/check_membership/action.yml
@@ -10,7 +10,7 @@ inputs:
     required: true
   user:
     description: "The username"
-    default: ${{ github.actor }}
+    default: ${{ github.event.pull_request.user.login }}
     required: false
 outputs:
   is_member:


### PR DESCRIPTION
Using `merge_group` leads to strange behavior, as the workflow isn't able to recognize who the author is when run on a merge queue, therefore labeling the person as an external contributor. However, we still need the `merge_group` to trigger the workflow, otherwise the ruleset will fail. Therefore we trigger the workflow but still skip it from being executed.