### PR TITLE
disable workflow for merge queue

### DIFF
--- a/.github/workflows/check_cla.yml
+++ b/.github/workflows/check_cla.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     # Dont run this workflow if it was triggered by one of these bots
     # Don't run it during a merge queue, as it can't correctly identify the actor
-    if:  github.actor != "dependabot[bot]" && github.actor != "github-actions[bot]" && github.event_name != 'merge_group'
+    if:  ${{ github.actor != "dependabot[bot]" && github.actor != "github-actions[bot]" && github.event_name != 'merge_group' }}
     outputs:
       is_member: ${{ steps.check-membership.outputs.is_member}}
     steps:

--- a/.github/workflows/check_cla.yml
+++ b/.github/workflows/check_cla.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     # Dont run this workflow if it was triggered by one of these bots
     # Don't run it during a merge queue, as it can't correctly identify the actor
-    if:  ${{ github.actor != "dependabot[bot]" && github.actor != "github-actions[bot]" && github.event_name != 'merge_group' }}
+    if:  ${{ github.actor != 'dependabot[bot]' && github.actor != 'github-actions[bot]' && github.event_name != 'merge_group' }}
     outputs:
       is_member: ${{ steps.check-membership.outputs.is_member}}
     steps:

--- a/.github/workflows/check_cla.yml
+++ b/.github/workflows/check_cla.yml
@@ -20,7 +20,10 @@ jobs:
     name: Check Membership
     runs-on: ubuntu-latest
     # Dont run this workflow if it was triggered by one of these bots
-    if: contains(fromJson('["dependabot[bot]", "github-actions[bot]", "github-merge-queue[bot]"]'), github.actor) == false
+    # Don't run it during a merge queue, as it can't correctly identify the actor
+    if:  |
+      (contains(fromJson('["dependabot[bot]", "github-actions[bot]"), github.actor) == false) &&
+      github.event_name != 'merge_group'
     outputs:
       is_member: ${{ steps.check-membership.outputs.is_member}}
     steps:

--- a/.github/workflows/check_cla.yml
+++ b/.github/workflows/check_cla.yml
@@ -22,7 +22,7 @@ jobs:
     # Dont run this workflow if it was triggered by one of these bots
     # Don't run it during a merge queue, as it can't correctly identify the actor
     if:  |
-      (contains(fromJson('["dependabot[bot]", "github-actions[bot]"), github.actor) == false) &&
+      github.actor != "dependabot[bot]" && github.actor != "github-actions[bot]" &&
       github.event_name != 'merge_group'
     outputs:
       is_member: ${{ steps.check-membership.outputs.is_member}}

--- a/.github/workflows/check_cla.yml
+++ b/.github/workflows/check_cla.yml
@@ -21,9 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     # Dont run this workflow if it was triggered by one of these bots
     # Don't run it during a merge queue, as it can't correctly identify the actor
-    if:  |
-      github.actor != "dependabot[bot]" && github.actor != "github-actions[bot]" &&
-      github.event_name != 'merge_group'
+    if:  github.actor != "dependabot[bot]" && github.actor != "github-actions[bot]" && github.event_name != 'merge_group'
     outputs:
       is_member: ${{ steps.check-membership.outputs.is_member}}
     steps:

--- a/.github/workflows/check_cla.yml
+++ b/.github/workflows/check_cla.yml
@@ -22,7 +22,7 @@ jobs:
     # Dont run this workflow if it was triggered by one of these bots
     # Don't run it during a merge queue, as it can't correctly identify the actor
     if:  |
-      (contains(fromJson('["dependabot[bot]", "github-actions[bot]"), github.actor) == false) &&
+      (contains(fromJson('["dependabot[bot]", "github-actions[bot]"), github.actor) == false) ||
       github.event_name != 'merge_group'
     outputs:
       is_member: ${{ steps.check-membership.outputs.is_member}}

--- a/.github/workflows/check_cla.yml
+++ b/.github/workflows/check_cla.yml
@@ -22,7 +22,7 @@ jobs:
     # Dont run this workflow if it was triggered by one of these bots
     # Don't run it during a merge queue, as it can't correctly identify the actor
     if:  |
-      (contains(fromJson('["dependabot[bot]", "github-actions[bot]"), github.actor) == false) ||
+      (contains(fromJson('["dependabot[bot]", "github-actions[bot]"), github.actor) == false) &&
       github.event_name != 'merge_group'
     outputs:
       is_member: ${{ steps.check-membership.outputs.is_member}}


### PR DESCRIPTION
I tested this out and the behavior does not match up with what is described [here](https://github.com/orgs/community/discussions/58673). The `github-merge-queue[bot]` does not show up as the actor for a merge queue. 

For merge queues:
`github.actor`: person who created PR
`github.event.sender.login`: person who created the PR
`github.event.pull_request.user.login`: empty for merge queue

It looks like my original idea to just skip the merge group is the best option.