### PR TITLE
dont raise exception

### DIFF
--- a/reusable_workflows/check_membership/check_membership.py
+++ b/reusable_workflows/check_membership/check_membership.py
@@ -18,9 +18,12 @@ def main() -> None:
     gh = github3.login(token=gh_token)
 
     if not gh:
-        raise Exception("github login failed - maybe GH_TOKEN was not correctly set")
+        # Todo: change to Exception once GH_TOKEN can be passed in from forked repositories
+        print("github login failed - maybe GH_TOKEN was not correctly set")
+        is_member = False
 
-    is_member = is_member_of_org(gh, org, user)
+    else:
+        is_member = is_member_of_org(gh, org, user)
 
     if is_member:
         print(f"{user} is member of {org} and can contribute.")

--- a/reusable_workflows/tests/test_membership.py
+++ b/reusable_workflows/tests/test_membership.py
@@ -92,12 +92,13 @@ def test_end_to_end_api_fails(os_system, github_login_mock):
 
 @mock.patch.dict(os.environ, {"GH_ORG": "my_org", "GH_TOKEN": "", "USER": "username"})
 @mock.patch("github3.login")
-def test_github_token_not_passed_in(github_login_mock):
+def test_github_token_not_passed_in(github_login_mock, capfd):
     github_login_mock.return_value = None
 
     main()
+    out, err = capfd.readouterr()
 
-    assert is_member is False
+    assert out == "username is member of my_org and can contribute.\n"
 
     # Todo: switch back once exception is added back
     # with pytest.raises(Exception) as exc:

--- a/reusable_workflows/tests/test_membership.py
+++ b/reusable_workflows/tests/test_membership.py
@@ -90,16 +90,19 @@ def test_end_to_end_api_fails(os_system, github_login_mock):
         os_system.assert_not_called()
 
 
-@mock.patch.dict(
-    os.environ, {"GH_ORG": "my_org", "GH_TOKEN": "", "USER": "username"}
-)
+@mock.patch.dict(os.environ, {"GH_ORG": "my_org", "GH_TOKEN": "", "USER": "username"})
 @mock.patch("github3.login")
 def test_github_token_not_passed_in(github_login_mock):
     github_login_mock.return_value = None
 
-    with pytest.raises(Exception) as exc:
-        main()
+    main()
 
-    assert (
-        str(exc.value) == "github login failed - maybe GH_TOKEN was not correctly set"
-    )
+    assert is_member is False
+
+    # Todo: switch back once exception is added back
+    # with pytest.raises(Exception) as exc:
+    #     main()
+
+    # assert (
+    #     str(exc.value) == "github login failed - maybe GH_TOKEN was not correctly set"
+    # )

--- a/reusable_workflows/tests/test_membership.py
+++ b/reusable_workflows/tests/test_membership.py
@@ -98,7 +98,7 @@ def test_github_token_not_passed_in(github_login_mock, capfd):
     main()
     out, err = capfd.readouterr()
 
-    assert out == "username is member of my_org and can contribute.\n"
+    assert out == "username is an external contributor.\n"
 
     # Todo: switch back once exception is added back
     # with pytest.raises(Exception) as exc:

--- a/reusable_workflows/tests/test_membership.py
+++ b/reusable_workflows/tests/test_membership.py
@@ -98,7 +98,10 @@ def test_github_token_not_passed_in(github_login_mock, capfd):
     main()
     out, err = capfd.readouterr()
 
-    assert out == "username is an external contributor.\n"
+    assert (
+        out
+        == "github login failed - maybe GH_TOKEN was not correctly set\nusername is an external contributor.\n"
+    )
 
     # Todo: switch back once exception is added back
     # with pytest.raises(Exception) as exc:

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,4 +9,4 @@ ignore_missing_imports = True
 ignore_missing_imports = True
 
 [flake8]
-ignore = E501
+ignore = E501, W503


### PR DESCRIPTION
The old bot was causing some issues, so I'd like to move to repos to this new workflow. The only problems is that forked repositories don't work with rulesets because `pull_request_target` is not supported. This change classifies any github authentication error as an external contributor and the PR will be automatically closed. This is only until `pull_request_target` is supported by rulesets.