### PR TITLE
Revert "dont raise exception"

### DIFF
--- a/reusable_workflows/check_membership/check_membership.py
+++ b/reusable_workflows/check_membership/check_membership.py
@@ -18,12 +18,9 @@ def main() -> None:
     gh = github3.login(token=gh_token)
 
     if not gh:
-        # Todo: change to Exception once GH_TOKEN can be passed in from forked repositories
-        print("github login failed - maybe GH_TOKEN was not correctly set")
-        is_member = False
+        raise Exception("github login failed - maybe GH_TOKEN was not correctly set")
 
-    else:
-        is_member = is_member_of_org(gh, org, user)
+    is_member = is_member_of_org(gh, org, user)
 
     if is_member:
         print(f"{user} is member of {org} and can contribute.")

--- a/reusable_workflows/tests/test_membership.py
+++ b/reusable_workflows/tests/test_membership.py
@@ -90,23 +90,16 @@ def test_end_to_end_api_fails(os_system, github_login_mock):
         os_system.assert_not_called()
 
 
-@mock.patch.dict(os.environ, {"GH_ORG": "my_org", "GH_TOKEN": "", "USER": "username"})
+@mock.patch.dict(
+    os.environ, {"GH_ORG": "my_org", "GH_TOKEN": "", "USER": "username"}
+)
 @mock.patch("github3.login")
-def test_github_token_not_passed_in(github_login_mock, capfd):
+def test_github_token_not_passed_in(github_login_mock):
     github_login_mock.return_value = None
 
-    main()
-    out, err = capfd.readouterr()
+    with pytest.raises(Exception) as exc:
+        main()
 
     assert (
-        out
-        == "github login failed - maybe GH_TOKEN was not correctly set\nusername is an external contributor.\n"
+        str(exc.value) == "github login failed - maybe GH_TOKEN was not correctly set"
     )
-
-    # Todo: switch back once exception is added back
-    # with pytest.raises(Exception) as exc:
-    #     main()
-
-    # assert (
-    #     str(exc.value) == "github login failed - maybe GH_TOKEN was not correctly set"
-    # )

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,4 +9,4 @@ ignore_missing_imports = True
 ignore_missing_imports = True
 
 [flake8]
-ignore = E501, W503
+ignore = E501


### PR DESCRIPTION
Now that `pull_request_target` is available we can use secrets.

Reverts dfinity/public-workflows#22