### PR TITLE
Update trigger

### DIFF
--- a/.github/workflows/check_cla.yml
+++ b/.github/workflows/check_cla.yml
@@ -9,6 +9,10 @@ on:
     branches:
       - 'master'
       - 'main'
+  pull_request:
+    paths:
+      - reusable_workflows/**
+      - requirements.txt
   merge_group:
   # we do not need this workflow to run on merge_group because its whole purpose is to check if the PR is mergeable
   # to test changes to this workflow, it needs to be manually run on the specific branch

--- a/.github/workflows/check_cla.yml
+++ b/.github/workflows/check_cla.yml
@@ -11,9 +11,9 @@ on:
       - 'main'
   pull_request:
     paths:
-      - .github/workflows/**
-      - reusable_workflows/**
-      - requirements.txt
+      - .github/workflows/check_cla.yml
+      - reusable_workflows/check_cla/**
+      - reusable_workflows/check_membership/**
   merge_group:
   # we do not need this workflow to run on merge_group because its whole purpose is to check if the PR is mergeable
   # to test changes to this workflow, it needs to be manually run on the specific branch

--- a/.github/workflows/check_cla.yml
+++ b/.github/workflows/check_cla.yml
@@ -11,6 +11,7 @@ on:
       - 'main'
   pull_request:
     paths:
+      - .github/workflows/**
       - reusable_workflows/**
       - requirements.txt
   merge_group:


### PR DESCRIPTION
Looks like I accidentally broke the workflow. How this happened:

- changed the CLA workflow
- because it is only triggered on `pull_request_target` and run on the master branch it succeeded
- changes to the workflow were merged
- workflow is broken

Because we don't expect external contributors to make any changes to the workflow itself, this filtering logic should enable internal developers to still make changes and test the workflow when necessary.