### PR TITLE
Remove merge_group trigger on workflow

### DIFF
--- a/.github/workflows/check_cla_ruleset.yml
+++ b/.github/workflows/check_cla_ruleset.yml
@@ -9,7 +9,6 @@ on:
     branches:
       - 'master'
       - 'main'
-  merge_group:
 
 jobs:
   call-check-cla:


### PR DESCRIPTION
Tested it out and it fails: https://github.com/dfinity/test-compliant-repository-public/actions/runs/6705207237/job/18219172484

Test if merge_group can be removed completely