### PR TITLE
Update pending label

### DIFF
--- a/reusable_workflows/check_cla/check_cla_pr.py
+++ b/reusable_workflows/check_cla/check_cla_pr.py
@@ -73,19 +73,20 @@ class CLAHandler:
             ),
         )
         # replace with PENDING, once new bot has been released
-        issue.add_labels(GH_WORKFLOW_LABEL)
+        issue.add_labels(PENDING_LABEL)
         return issue
 
     def handle_cla_signed(self, issue: GHIssue, user: str) -> None:
         for label in issue.original_labels:
             if label.name == APPROVED_LABEL:
                 return
-            elif label.name == GH_WORKFLOW_LABEL:
-                agreement_message = messages.AGREED_MESSAGE.format(user)
-                issue.create_comment(agreement_message)
-                issue.remove_label(GH_WORKFLOW_LABEL)
-                issue.add_labels(APPROVED_LABEL)
-                return
+            for pending_label in [GH_WORKFLOW_LABEL, PENDING_LABEL]:
+                if label.name == pending_label:
+                    agreement_message = messages.AGREED_MESSAGE.format(user)
+                    issue.create_comment(agreement_message)
+                    issue.remove_label(pending_label)
+                    issue.add_labels(APPROVED_LABEL)
+                    return
         print(
             "No cla labels found - manually check the cla issue to see what state it is in. Exiting program."  # noqa
         )

--- a/reusable_workflows/check_cla/check_cla_pr.py
+++ b/reusable_workflows/check_cla/check_cla_pr.py
@@ -72,7 +72,6 @@ class CLAHandler:
                 user, self.cla_link, user_agreement_message
             ),
         )
-        # replace with PENDING, once new bot has been released
         issue.add_labels(PENDING_LABEL)
         return issue
 

--- a/reusable_workflows/tests/test_cla_pr.py
+++ b/reusable_workflows/tests/test_cla_pr.py
@@ -142,6 +142,7 @@ def test_create_cla_issue():
         "cla: @username",
         body=cla_agreement_message,
     )
+    issue.add_labels.assert_called_with("cla:pending")
 
 
 def test_handle_cla_signed_with_agreed_label():
@@ -171,6 +172,19 @@ def test_handle_cla_signed_with_pending_label():
     issue.remove_label.assert_called_once()
     issue.add_labels.assert_called_once()
 
+def test_handle_cla_signed_with_new_pending_label():
+    issue = mock.Mock()
+    label = mock.Mock()
+    label.name = "cla:pending"
+    issue.original_labels = [label]
+    agreement_message = AGREED_MESSAGE.format("username")
+
+    cla = CLAHandler(mock.Mock())
+    cla.handle_cla_signed(issue, "username")
+
+    issue.create_comment.assert_called_with(agreement_message)
+    issue.remove_label.assert_called_once()
+    issue.add_labels.assert_called_once()
 
 def test_handle_cla_signed_with_no_label(capfd):
     issue = mock.Mock()


### PR DESCRIPTION
When we initially launched the workflow we created a new pending label `cla:gh-wf-pending` so that the new bot and old bot wouldn't interfere. Now that we are shutting down the old bot, we need the cla workflow to check for both labels, but assign new issues the `cla:pending` one.