### PR TITLE
fix(IDX): change closing message

### DIFF
--- a/.github/workflows/check_cla.yml
+++ b/.github/workflows/check_cla.yml
@@ -77,11 +77,13 @@ jobs:
         uses: superbrothers/close-pull-request@v3
         with:
           comment: |
-            "This repository does not accept external contributions yet.
-  
-            We are therefore closing this Pull Request, thank you for your understanding.
-  
-            — The DFINITY Foundation"
+            Thank you for contributing! Unfortunately this repository does not accept external contributions yet.
+
+            We are working on enabling this by aligning our internal processes and our CI setup to handle external contributions. However this will take some time to set up so in the meantime we unfortunately have to close this Pull Request.
+
+            We hope you understand and will come back once we accept external PRs.
+
+            — The DFINITY Foundation"""
 
       - name: Add Label
         uses: actions/github-script@v6

--- a/reusable_workflows/shared/messages.py
+++ b/reusable_workflows/shared/messages.py
@@ -1,14 +1,4 @@
 # Messages
-CLOSING_MESSAGE = """Dear @{},
-
-Thank you for contributing! Unfortunately this repository does not accept external contributions yet.
-
-We are working on enabling this by aligning our internal processes and our CI setup to handle external contributions. However this will take some time to set up so in the meantime we unfortunately have to close this Pull Request.
-
-We hope you understand and will come back once we accept external PRs.
-
-— The DFINITY Foundation"""
-
 USER_AGREEMENT_MESSAGE = "I, {}, hereby agree to the DFINITY Foundation's CLA."
 
 CLA_MESSAGE = """Dear @{},


### PR DESCRIPTION
I didn't realize that the closing message is actually defined in the workflow itself. I'm guessing I did it that way because closing the PR programmatically was too complex.