### PR TITLE
test(IDX): switch from main to tag

### DIFF
--- a/.github/workflows/check_cla_dev.yml
+++ b/.github/workflows/check_cla_dev.yml
@@ -11,5 +11,5 @@ on:
 
 jobs:
   call-check-cla:
-    uses: ./.github/workflows/check_cla.yml
+    uses: ./.github/workflows/check_cla.yml@manual-05-09-2024
     secrets: inherit

--- a/.github/workflows/check_cla_dev.yml
+++ b/.github/workflows/check_cla_dev.yml
@@ -12,5 +12,5 @@ on:
 
 jobs:
   call-check-cla:
-    uses: ./.github/workflows/check_cla.yml@manual-05-09-2024
+    uses: dfinity/public-workflows/.github/workflows/check_cla.yml@manual-05-09-2024
     secrets: inherit

--- a/.github/workflows/check_cla_dev.yml
+++ b/.github/workflows/check_cla_dev.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
     paths:
       - .github/workflows/check_cla.yml
+      - .github/workflows/check_cla_dev.yml
       - reusable_workflows/check_cla/**
       - reusable_workflows/check_membership/**
 

--- a/.github/workflows/check_cla_dev.yml
+++ b/.github/workflows/check_cla_dev.yml
@@ -12,5 +12,5 @@ on:
 
 jobs:
   call-check-cla:
-    uses: dfinity/public-workflows/.github/workflows/check_cla.yml@manual-05-09-2024
+    uses: ./.github/workflows/check_cla.yml
     secrets: inherit

--- a/.github/workflows/check_cla_ruleset.yml
+++ b/.github/workflows/check_cla_ruleset.yml
@@ -13,5 +13,5 @@ on:
 
 jobs:
   call-check-cla:
-    uses: dfinity/public-workflows/.github/workflows/check_cla.yml@main
+    uses: dfinity/public-workflows/.github/workflows/check_cla.yml@manual-05-09-2024
     secrets: inherit

--- a/README.md
+++ b/README.md
@@ -13,4 +13,4 @@ If a new change needs to be deployed a new tag needs to be created. Currently th
 git tag <tagname>
 git push origin --tags
 ```
-This will allow you to test out the workflow first if you'd like (we have a ruleset called CLA check (dev)), otherwise update the main ruleset CLA-check with the correct tag.
+Then update the tag in the workflow `.github/workflows/check_cla_ruleset.yml`.


### PR DESCRIPTION
Instead of having the ruleset pointing to a specific tag and the code pointing to `main` I'd like to switch it -> now the code will point to the new tag and the ruleset will point to main. This will have two benefits:

1. Only a code change is required and no additional changes to the ruleset
2. I'm hoping it will fix the issue where workflows are blocked because the tag on the ruleset was changed