### PR TITLE
fix(IDX): remove pending label

### DIFF
--- a/reusable_workflows/check_cla/check_cla_pr.py
+++ b/reusable_workflows/check_cla/check_cla_pr.py
@@ -68,8 +68,8 @@ class CLAHandler:
             body=messages.CLA_AGREEMENT_MESSAGE.format(
                 user, self.cla_link, user_agreement_message, pr_url
             ),
+            labels=[PENDING_LABEL]
         )
-        issue.add_labels(PENDING_LABEL)
         return issue
 
     def handle_cla_signed(self, issue: GHIssue, user: str) -> None:

--- a/reusable_workflows/check_cla/check_cla_pr.py
+++ b/reusable_workflows/check_cla/check_cla_pr.py
@@ -68,7 +68,6 @@ class CLAHandler:
             body=messages.CLA_AGREEMENT_MESSAGE.format(
                 user, self.cla_link, user_agreement_message, pr_url
             ),
-            labels=[PENDING_LABEL]
         )
         return issue
 
@@ -76,17 +75,16 @@ class CLAHandler:
         for label in issue.original_labels:
             if label.name == APPROVED_LABEL:
                 return
+
+            # if a pending label exists, remove it
             for pending_label in [GH_WORKFLOW_LABEL, PENDING_LABEL]:
                 if label.name == pending_label:
-                    agreement_message = messages.AGREED_MESSAGE.format(user)
-                    issue.create_comment(agreement_message)
                     issue.remove_label(pending_label)
-                    issue.add_labels(APPROVED_LABEL)
-                    return
-        print(
-            "No cla labels found - manually check the cla issue to see what state it is in. Exiting program."  # noqa
-        )
-        sys.exit(1)
+
+        # once all pending labels have been removed and no approved label was found, add the agreement message with an approved label
+        agreement_message = messages.AGREED_MESSAGE.format(user)
+        issue.create_comment(agreement_message)
+        issue.add_labels(APPROVED_LABEL)
 
 
 def main() -> None:

--- a/reusable_workflows/tests/test_cla_pr.py
+++ b/reusable_workflows/tests/test_cla_pr.py
@@ -142,7 +142,6 @@ def test_create_cla_issue():
         "cla: @username",
         body=cla_agreement_message,
     )
-    issue.add_labels.assert_called_with("cla:pending")
 
 
 def test_handle_cla_signed_with_agreed_label():
@@ -158,22 +157,19 @@ def test_handle_cla_signed_with_agreed_label():
     issue.remove_label.assert_not_called()
 
 
-def test_handle_cla_signed_with_pending_label():
+def test_handle_cla_signed_with_no_label():
     issue = mock.Mock()
-    label = mock.Mock()
-    label.name = "cla:gh-wf-pending"
-    issue.original_labels = [label]
+    issue.original_labels = []
     agreement_message = AGREED_MESSAGE.format("username")
 
     cla = CLAHandler(mock.Mock())
     cla.handle_cla_signed(issue, "username")
 
     issue.create_comment.assert_called_with(agreement_message)
-    issue.remove_label.assert_called_once()
     issue.add_labels.assert_called_once()
 
 
-def test_handle_cla_signed_with_new_pending_label():
+def test_handle_cla_signed_with_old_pending_label():
     issue = mock.Mock()
     label = mock.Mock()
     label.name = "cla:pending"
@@ -186,17 +182,6 @@ def test_handle_cla_signed_with_new_pending_label():
     issue.create_comment.assert_called_with(agreement_message)
     issue.remove_label.assert_called_once()
     issue.add_labels.assert_called_once()
-
-
-def test_handle_cla_signed_with_no_label(capfd):
-    issue = mock.Mock()
-    issue.original_labels = []
-
-    with pytest.raises(SystemExit):
-        cla = CLAHandler(mock.Mock())
-        cla.handle_cla_signed(issue, "username")
-        out, err = capfd.readouterr()
-        assert out == "No cla labels found - manually check the cla issue to see what state it is in. Exiting program.\n"  # fmt: skip
 
 
 @mock.patch.dict(


### PR DESCRIPTION
Since migrating the cla workflow from the service account to the GitHub App a permissions error gets triggered when adding the `pending` label to the issue. I've tried to debug, but I haven't been able to replicate the error using my user account - my guess is there's something that is different in how bots get permissions vs users.

Since this is the only problem and setting the `approved` label still works fine I have decided that having the `pending` label is not crucial and I am removing it. 