### PR TITLE
fix(IDX): run git commands in a different dir

### DIFF
--- a/.github/workflows/repo_policies.yml
+++ b/.github/workflows/repo_policies.yml
@@ -42,3 +42,4 @@ jobs:
           REPO: ${{ github.event.repository.name }}
           MERGE_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           BRANCH_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          REPO_PATH: current-repo

--- a/.github/workflows/repo_policies_ruleset.yml
+++ b/.github/workflows/repo_policies_ruleset.yml
@@ -8,5 +8,5 @@ on:
 
 jobs:
   call-repo-policies:
-    uses: dfinity/public-workflows/.github/workflows/repo_policies.yml@run-git-commands-from-within-dir
+    uses: dfinity/public-workflows/.github/workflows/repo_policies.yml@main
     secrets: inherit

--- a/.github/workflows/repo_policies_ruleset.yml
+++ b/.github/workflows/repo_policies_ruleset.yml
@@ -8,5 +8,5 @@ on:
 
 jobs:
   call-repo-policies:
-    uses: dfinity/public-workflows/.github/workflows/repo_policies.yml@main
+    uses: dfinity/public-workflows/.github/workflows/repo_policies.yml@run-git-commands-from-within-dir
     secrets: inherit

--- a/reusable_workflows/repo_policies/bot_checks/check_bot_approved_files.py
+++ b/reusable_workflows/repo_policies/bot_checks/check_bot_approved_files.py
@@ -1,4 +1,5 @@
 import subprocess
+from typing import Optional
 
 import github3
 
@@ -11,12 +12,13 @@ REQUIRED_ENV_VARS = [
     "GH_TOKEN",
     "GH_ORG",
     "REPO",
+    "REPO_PATH"
     "MERGE_BASE_SHA",
     "BRANCH_HEAD_SHA",
 ]
 
 
-def get_changed_files(merge_base_sha: str, branch_head_sha: str) -> list[str]:
+def get_changed_files(merge_base_sha: str, branch_head_sha: str, repo_path : Optional[str] = None) -> list[str]:
     """
     Compares the files changed in the current branch to the merge base.
     """
@@ -25,6 +27,7 @@ def get_changed_files(merge_base_sha: str, branch_head_sha: str) -> list[str]:
         ["git", "diff", "--name-only", commit_range],
         capture_output=True,
         text=True,
+        cwd=repo_path,
     )
     if result.returncode != 0:
         raise RuntimeError(f"git diff failed with exit code {result.returncode}: {result.stderr}")
@@ -61,8 +64,9 @@ def check_if_pr_is_blocked(env_vars: dict) -> None:
     """
     gh = github3.login(token=env_vars["GH_TOKEN"])
     repo = gh.repository(owner=env_vars["GH_ORG"], repository=env_vars["REPO"])
+    repo_path = env_vars["REPO_PATH"]
     changed_files = get_changed_files(
-        env_vars["MERGE_BASE_SHA"], env_vars["BRANCH_HEAD_SHA"]
+        env_vars["MERGE_BASE_SHA"], env_vars["BRANCH_HEAD_SHA"], repo_path
     )
     config = get_approved_files_config(repo)
     approved_files = get_approved_files(config)

--- a/reusable_workflows/repo_policies/bot_checks/check_bot_approved_files.py
+++ b/reusable_workflows/repo_policies/bot_checks/check_bot_approved_files.py
@@ -12,7 +12,7 @@ REQUIRED_ENV_VARS = [
     "GH_TOKEN",
     "GH_ORG",
     "REPO",
-    "REPO_PATH"
+    "REPO_PATH",
     "MERGE_BASE_SHA",
     "BRANCH_HEAD_SHA",
 ]

--- a/reusable_workflows/repo_policies/bot_checks/check_bot_approved_files.py
+++ b/reusable_workflows/repo_policies/bot_checks/check_bot_approved_files.py
@@ -18,7 +18,7 @@ REQUIRED_ENV_VARS = [
 ]
 
 
-def get_changed_files(merge_base_sha: str, branch_head_sha: str, repo_path : Optional[str] = None) -> list[str]:
+def get_changed_files(merge_base_sha: str, branch_head_sha: str, repo_path: Optional[str] = None) -> list[str]:
     """
     Compares the files changed in the current branch to the merge base.
     """

--- a/reusable_workflows/tests/test_repo_policies.py
+++ b/reusable_workflows/tests/test_repo_policies.py
@@ -26,6 +26,7 @@ def test_get_changed_files(mock_subprocess_run):
         ["git", "diff", "--name-only", "merge_base_sha..branch_head_sha"],
         capture_output=True,
         text=True,
+        cwd=None,
     )
 
 
@@ -74,6 +75,7 @@ def test_pr_is_blocked_false(gh_login, get_approved_files_config, get_changed_fi
         "GH_TOKEN": "token",
         "GH_ORG": "org",
         "REPO": "repo",
+        "REPO_PATH": "path",
         "MERGE_BASE_SHA": "base",
         "BRANCH_HEAD_SHA": "head",
     }
@@ -89,7 +91,7 @@ def test_pr_is_blocked_false(gh_login, get_approved_files_config, get_changed_fi
 
     check_if_pr_is_blocked(env_vars)
 
-    get_changed_files.assert_called_once_with("base", "head")
+    get_changed_files.assert_called_once_with("base", "head", "path")
     get_approved_files_config.assert_called_once_with(repo)
 
 
@@ -103,6 +105,7 @@ def test_pr_is_blocked_true(gh_login, get_approved_files_config, get_changed_fil
         "GH_TOKEN": "token",
         "GH_ORG": "org",
         "REPO": "repo",
+        "REPO_PATH": "path",
         "MERGE_BASE_SHA": "base",
         "BRANCH_HEAD_SHA": "head",
     }
@@ -119,7 +122,7 @@ def test_pr_is_blocked_true(gh_login, get_approved_files_config, get_changed_fil
     with pytest.raises(SystemExit):
         check_if_pr_is_blocked(env_vars)
 
-    get_changed_files.assert_called_once_with("base", "head")
+    get_changed_files.assert_called_once_with("base", "head", "path")
     get_approved_files_config.assert_called_once_with(repo)
 
 


### PR DESCRIPTION
Because of the multi-repo checkout step we need to specify which directory the git commands should be run in.