### PR TITLE
feat(IDX): add internal-external workflow

### DIFF
--- a/.github/workflows/internal_vs_external.yml
+++ b/.github/workflows/internal_vs_external.yml
@@ -45,7 +45,7 @@ jobs:
   revoke-approvals:
     name: Revoke Approvals
     runs-on: ubuntu-latest
-    needs: check-membership
+  #  needs: check-membership
   #  if: ${{ needs.check-membership.outputs.is_member != 'true' && needs.check-membership.result == 'success' }}
     steps:
       - name: Create GitHub App Token

--- a/.github/workflows/internal_vs_external.yml
+++ b/.github/workflows/internal_vs_external.yml
@@ -67,10 +67,10 @@ jobs:
           fi
 
           for review_id in $(echo "${reviews}" | jq -r '.[] | select(.state == "APPROVED") | .id'); do
-            curl -s -X PUT -H "Authorization: token ${GH_TOKEN}" \
+            response=$(curl -s -o /dev/null -w "%{http_code}" -X PUT -H "Authorization: token ${GH_TOKEN}" \
               -H "Accept: application/vnd.github.v3+json" \
               -d '{"message": "Review dismissed by automation script."}' \
-              "https://api.github.com/repos/${GH_ORG}/${REPO}/pulls/${PULL_NUMBER}/reviews/${review_id}/dismissals"
+              "https://api.github.com/repos/${GH_ORG}/${REPO}/pulls/${PULL_NUMBER}/reviews/${review_id}/dismissals")
             if [ "$response" -eq 200 ]; then
               echo "Dismissed review ${review_id}"
             else

--- a/.github/workflows/internal_vs_external.yml
+++ b/.github/workflows/internal_vs_external.yml
@@ -54,7 +54,6 @@ jobs:
     steps:
       - name: Dismiss Pull Request Reviews
         run: |
-          #!/bin/bash
           set -euo pipefail
 
           # get existing reviews

--- a/.github/workflows/internal_vs_external.yml
+++ b/.github/workflows/internal_vs_external.yml
@@ -52,8 +52,8 @@ jobs:
         uses: actions/create-github-app-token@v1
         id: app-token
         with:
-          app-id: ${{ vars.PR_AUTOMATION_BOT_PUBLIC_APP_ID }}
-          private-key: ${{ secrets.PR_AUTOMATION_BOT_PUBLIC_PRIVATE_KEY }} # the PR Automation Bot has permissions to dismiss pull request reviews
+          app-id: ${{ vars.CLA_BOT_APP_ID }}
+          private-key: ${{ secrets.CLA_BOT_PRIVATE_KEY }} # the CLA Bot has permissions to dismiss pull request reviews
 
       - name: Dismiss Pull Request Reviews
         run: |
@@ -77,7 +77,7 @@ jobs:
           done
         shell: bash
         env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           GH_ORG: ${{ github.repository_owner }}
           REPO: ${{ github.event.repository.name }}
           PULL_NUMBER: ${{ github.event.pull_request.number }}          

--- a/.github/workflows/internal_vs_external.yml
+++ b/.github/workflows/internal_vs_external.yml
@@ -14,58 +14,60 @@ permissions:
   pull-requests: write
 
 jobs:
-  # check-membership:
-  #   name: Check Membership
-  #   runs-on: ubuntu-latest
-  #   # Dont run this workflow on merge queue
-  #   if:  ${{ github.event_name != 'merge_group' }}
-  #   outputs:
-  #     is_member: ${{ steps.check-membership.outputs.is_member}}
-  #   steps:
-  #     - name: Create GitHub App Token
-  #       uses: actions/create-github-app-token@v1
-  #       id: app-token
-  #       with:
-  #         app-id: ${{ vars.CLA_BOT_APP_ID }}
-  #         private-key: ${{ secrets.CLA_BOT_PRIVATE_KEY }}
+  check-membership:
+    name: Check Membership
+    runs-on: ubuntu-latest
+    # Dont run this workflow on merge queue
+    if:  ${{ github.event_name != 'merge_group' }}
+    outputs:
+      is_member: ${{ steps.check-membership.outputs.is_member}}
+    steps:
+      - name: Create GitHub App Token
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.CLA_BOT_APP_ID }}
+          private-key: ${{ secrets.CLA_BOT_PRIVATE_KEY }}
     
-  #     - name: Checkout
-  #       uses: actions/checkout@v4
-  #       with:
-  #         repository: 'dfinity/public-workflows'
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          repository: 'dfinity/public-workflows'
 
-  #     - name: Python Setup
-  #       uses: ./.github/workflows/python-setup
+      - name: Python Setup
+        uses: ./.github/workflows/python-setup
         
-  #     - name: Check Membership
-  #       id:  check-membership
-  #       run: python reusable_workflows/check_membership/check_membership.py
-  #       shell: bash
-  #       env:
-  #         GH_TOKEN: ${{ steps.app-token.outputs.token }}
-  #         GH_ORG: ${{ github.repository_owner }}
-  #         USER: ${{ github.event.pull_request.user.login }}
+      - name: Check Membership
+        id:  check-membership
+        run: python reusable_workflows/check_membership/check_membership.py
+        shell: bash
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_ORG: ${{ github.repository_owner }}
+          USER: ${{ github.event.pull_request.user.login }}
 
   revoke-approvals:
     name: Revoke Approvals
     runs-on: ubuntu-latest
-  #  needs: check-membership
-  #  if: ${{ needs.check-membership.outputs.is_member != 'true' && needs.check-membership.result == 'success' }}
+    needs: check-membership
+    if: ${{ needs.check-membership.outputs.is_member != 'true' && needs.check-membership.result == 'success' }}
     steps:
       - name: Dismiss Pull Request Reviews
         run: |
           #!/bin/bash
           set -euo pipefail
 
+          # get existing reviews
           reviews=$(curl -s -H "Authorization: token ${GH_TOKEN}" \
             "https://api.github.com/repos/${GH_ORG}/${REPO}/pulls/${PULL_NUMBER}/reviews")
 
-          # Check if any reviews were found
+          # If no reviews were given, then exit script
           if [ -z "$reviews" ] || [ "$reviews" == "[]" ]; then
             echo "No reviews to dismiss"
             exit 0
           fi
 
+          # dismiss PR reviews
           for review_id in $(echo "${reviews}" | jq -r '.[] | select(.state == "APPROVED") | .id'); do
             response=$(curl -s -o /dev/null -w "%{http_code}" -X PUT -H "Authorization: token ${GH_TOKEN}" \
               -H "Accept: application/vnd.github.v3+json" \
@@ -80,7 +82,7 @@ jobs:
           done
         shell: bash
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }} # actor is github actions with above permissions
           GH_ORG: ${{ github.repository_owner }}
           REPO: ${{ github.event.repository.name }}
           PULL_NUMBER: ${{ github.event.pull_request.number }}          

--- a/.github/workflows/internal_vs_external.yml
+++ b/.github/workflows/internal_vs_external.yml
@@ -60,23 +60,21 @@ jobs:
           #!/bin/bash
           set -euo pipefail
 
-          gh auth status
+          reviews=$(curl -s -H "Authorization: token ${GH_TOKEN}" \
+            "https://api.github.com/repos/${GH_ORG}/${REPO}/pulls/${PULL_NUMBER}/reviews")
 
-          # reviews=$(curl -s -H "Authorization: token ${GH_TOKEN}" \
-          #   "https://api.github.com/repos/${GH_ORG}/${REPO}/pulls/${PULL_NUMBER}/reviews")
-
-          # for review_id in $(echo "${reviews}" | jq -r '.[] | select(.state == "APPROVED") | .id'); do
-          #   curl -s -X PUT -H "Authorization: token ${GH_TOKEN}" \
-          #     -H "Accept: application/vnd.github.v3+json" \
-          #     -d '{"message": "Review dismissed by automation script."}' \
-          #     "https://api.github.com/repos/${GH_ORG}/${REPO}/pulls/${PULL_NUMBER}/reviews/${review_id}/dismissals"
-          #   if [ "$response" -eq 200 ]; then
-          #     echo "Dismissed review ${review_id}"
-          #   else
-          #     echo "Failed to dismiss review ${review_id}, HTTP status code: $response"
-          #     exit 1
-          #   fi
-          # done
+          for review_id in $(echo "${reviews}" | jq -r '.[] | select(.state == "APPROVED") | .id'); do
+            curl -s -X PUT -H "Authorization: token ${GH_TOKEN}" \
+              -H "Accept: application/vnd.github.v3+json" \
+              -d '{"message": "Review dismissed by automation script."}' \
+              "https://api.github.com/repos/${GH_ORG}/${REPO}/pulls/${PULL_NUMBER}/reviews/${review_id}/dismissals"
+            if [ "$response" -eq 200 ]; then
+              echo "Dismissed review ${review_id}"
+            else
+              echo "Failed to dismiss review ${review_id}, HTTP status code: $response"
+              exit 1
+            fi
+          done
         shell: bash
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/internal_vs_external.yml
+++ b/.github/workflows/internal_vs_external.yml
@@ -62,12 +62,22 @@ jobs:
           reviews=$(curl -s -H "Authorization: token ${GH_TOKEN}" \
             "https://api.github.com/repos/${GH_ORG}/${REPO}/pulls/${PULL_NUMBER}/reviews")
 
+          # debug
+          user_info=$(curl -s -H "Authorization: token ${GH_TOKEN}" \
+            "https://api.github.com/user")
+          echo "User Info: $user_info"
+
           for review_id in $(echo "${reviews}" | jq -r '.[] | select(.state == "APPROVED") | .id'); do
             curl -s -X PUT -H "Authorization: token ${GH_TOKEN}" \
               -H "Accept: application/vnd.github.v3+json" \
               -d '{"message": "Review dismissed by automation script."}' \
               "https://api.github.com/repos/${GH_ORG}/${REPO}/pulls/${PULL_NUMBER}/reviews/${review_id}/dismissals"
-            echo "Dismissed review ${review_id}"
+            if [ "$response" -eq 200 ]; then
+              echo "Dismissed review ${review_id}"
+            else
+              echo "Failed to dismiss review ${review_id}, HTTP status code: $response"
+              exit 1
+            fi
           done
         shell: bash
         env:

--- a/.github/workflows/internal_vs_external.yml
+++ b/.github/workflows/internal_vs_external.yml
@@ -78,7 +78,6 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
-     #     GH_TOKEN: ${{ steps.app-token.outputs.token }}
           GH_ORG: ${{ github.repository_owner }}
           REPO: ${{ github.event.repository.name }}
           PULL_NUMBER: ${{ github.event.pull_request.number }}          

--- a/.github/workflows/internal_vs_external.yml
+++ b/.github/workflows/internal_vs_external.yml
@@ -58,27 +58,25 @@ jobs:
       - name: Dismiss Pull Request Reviews
         run: |
           #!/bin/bash
-          set -euox pipefail # REMOVE -x later!
-          reviews=$(curl -s -H "Authorization: token ${GH_TOKEN}" \
-            "https://api.github.com/repos/${GH_ORG}/${REPO}/pulls/${PULL_NUMBER}/reviews")
+          set -euo pipefail
+          # Check if the token has access to the repository
+          curl -sS -f -I -H "Authorization: token ${GH_TOKEN}" https://api.github.com | grep -i x-oauth-scopes
 
-          # debug
-          user_info=$(curl -s -H "Authorization: token ${GH_TOKEN}" \
-            "https://api.github.com/user")
-          echo "User Info: $user_info"
+          # reviews=$(curl -s -H "Authorization: token ${GH_TOKEN}" \
+          #   "https://api.github.com/repos/${GH_ORG}/${REPO}/pulls/${PULL_NUMBER}/reviews")
 
-          for review_id in $(echo "${reviews}" | jq -r '.[] | select(.state == "APPROVED") | .id'); do
-            curl -s -X PUT -H "Authorization: token ${GH_TOKEN}" \
-              -H "Accept: application/vnd.github.v3+json" \
-              -d '{"message": "Review dismissed by automation script."}' \
-              "https://api.github.com/repos/${GH_ORG}/${REPO}/pulls/${PULL_NUMBER}/reviews/${review_id}/dismissals"
-            if [ "$response" -eq 200 ]; then
-              echo "Dismissed review ${review_id}"
-            else
-              echo "Failed to dismiss review ${review_id}, HTTP status code: $response"
-              exit 1
-            fi
-          done
+          # for review_id in $(echo "${reviews}" | jq -r '.[] | select(.state == "APPROVED") | .id'); do
+          #   curl -s -X PUT -H "Authorization: token ${GH_TOKEN}" \
+          #     -H "Accept: application/vnd.github.v3+json" \
+          #     -d '{"message": "Review dismissed by automation script."}' \
+          #     "https://api.github.com/repos/${GH_ORG}/${REPO}/pulls/${PULL_NUMBER}/reviews/${review_id}/dismissals"
+          #   if [ "$response" -eq 200 ]; then
+          #     echo "Dismissed review ${review_id}"
+          #   else
+          #     echo "Failed to dismiss review ${review_id}, HTTP status code: $response"
+          #     exit 1
+          #   fi
+          # done
         shell: bash
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/internal_vs_external.yml
+++ b/.github/workflows/internal_vs_external.yml
@@ -77,7 +77,8 @@ jobs:
           done
         shell: bash
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+     #     GH_TOKEN: ${{ steps.app-token.outputs.token }}
           GH_ORG: ${{ github.repository_owner }}
           REPO: ${{ github.event.repository.name }}
           PULL_NUMBER: ${{ github.event.pull_request.number }}          

--- a/.github/workflows/internal_vs_external.yml
+++ b/.github/workflows/internal_vs_external.yml
@@ -9,6 +9,10 @@ on:
       - synchronize
   merge_group: # merge group is always needed for a required workflows to prevent them from getting stuck, but we then skip it below
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   # check-membership:
   #   name: Check Membership
@@ -48,13 +52,6 @@ jobs:
   #  needs: check-membership
   #  if: ${{ needs.check-membership.outputs.is_member != 'true' && needs.check-membership.result == 'success' }}
     steps:
-      - name: Create GitHub App Token
-        uses: actions/create-github-app-token@v1
-        id: app-token
-        with:
-          app-id: ${{ vars.CLA_BOT_APP_ID }}
-          private-key: ${{ secrets.CLA_BOT_PRIVATE_KEY }} # the CLA Bot has permissions to dismiss pull request reviews
-
       - name: Dismiss Pull Request Reviews
         run: |
           #!/bin/bash
@@ -83,7 +80,7 @@ jobs:
           done
         shell: bash
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_ORG: ${{ github.repository_owner }}
           REPO: ${{ github.event.repository.name }}
           PULL_NUMBER: ${{ github.event.pull_request.number }}          

--- a/.github/workflows/internal_vs_external.yml
+++ b/.github/workflows/internal_vs_external.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Dismiss Pull Request Reviews
         run: |
           #!/bin/bash
-          set -euo pipefail
+          set -euox pipefail # REMOVE -x later!
           reviews=$(curl -s -H "Authorization: token ${GH_TOKEN}" \
             "https://api.github.com/repos/${GH_ORG}/${REPO}/pulls/${PULL_NUMBER}/reviews")
 

--- a/.github/workflows/internal_vs_external.yml
+++ b/.github/workflows/internal_vs_external.yml
@@ -3,46 +3,50 @@
 name: Internal vs External Review
 
 on:
-  workflow_call:
+  pull_request:
+    types:
+      - ready_for_review
+      - synchronize
+  merge_group: # merge group is always needed for a required workflows to prevent them from getting stuck, but we then skip it below
 
 jobs:
-  check-membership:
-    name: Check Membership
-    runs-on: ubuntu-latest
-    # Dont run this workflow on merge queue
-    if:  ${{ github.event_name != 'merge_group' }}
-    outputs:
-      is_member: ${{ steps.check-membership.outputs.is_member}}
-    steps:
-      - name: Create GitHub App Token
-        uses: actions/create-github-app-token@v1
-        id: app-token
-        with:
-          app-id: ${{ vars.CLA_BOT_APP_ID }}
-          private-key: ${{ secrets.CLA_BOT_PRIVATE_KEY }}
+  # check-membership:
+  #   name: Check Membership
+  #   runs-on: ubuntu-latest
+  #   # Dont run this workflow on merge queue
+  #   if:  ${{ github.event_name != 'merge_group' }}
+  #   outputs:
+  #     is_member: ${{ steps.check-membership.outputs.is_member}}
+  #   steps:
+  #     - name: Create GitHub App Token
+  #       uses: actions/create-github-app-token@v1
+  #       id: app-token
+  #       with:
+  #         app-id: ${{ vars.CLA_BOT_APP_ID }}
+  #         private-key: ${{ secrets.CLA_BOT_PRIVATE_KEY }}
     
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          repository: 'dfinity/public-workflows'
+  #     - name: Checkout
+  #       uses: actions/checkout@v4
+  #       with:
+  #         repository: 'dfinity/public-workflows'
 
-      - name: Python Setup
-        uses: ./.github/workflows/python-setup
+  #     - name: Python Setup
+  #       uses: ./.github/workflows/python-setup
         
-      - name: Check Membership
-        id:  check-membership
-        run: python reusable_workflows/check_membership/check_membership.py
-        shell: bash
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          GH_ORG: ${{ github.repository_owner }}
-          USER: ${{ github.event.pull_request.user.login }}
+  #     - name: Check Membership
+  #       id:  check-membership
+  #       run: python reusable_workflows/check_membership/check_membership.py
+  #       shell: bash
+  #       env:
+  #         GH_TOKEN: ${{ steps.app-token.outputs.token }}
+  #         GH_ORG: ${{ github.repository_owner }}
+  #         USER: ${{ github.event.pull_request.user.login }}
 
   revoke-approvals:
     name: Revoke Approvals
     runs-on: ubuntu-latest
     needs: check-membership
-    if: ${{ needs.check-membership.outputs.is_member != 'true' && needs.check-membership.result == 'success' }}
+  #  if: ${{ needs.check-membership.outputs.is_member != 'true' && needs.check-membership.result == 'success' }}
     steps:
       - name: Create GitHub App Token
         uses: actions/create-github-app-token@v1

--- a/.github/workflows/internal_vs_external.yml
+++ b/.github/workflows/internal_vs_external.yml
@@ -1,0 +1,73 @@
+# Checks to see which reviews are required based on internal vs external contribution
+
+name: Internal vs External Review
+
+on:
+  workflow_call:
+
+jobs:
+  check-membership:
+    name: Check Membership
+    runs-on: ubuntu-latest
+    # Dont run this workflow on merge queue
+    if:  ${{ github.event_name != 'merge_group' }}
+    outputs:
+      is_member: ${{ steps.check-membership.outputs.is_member}}
+    steps:
+      - name: Create GitHub App Token
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.CLA_BOT_APP_ID }}
+          private-key: ${{ secrets.CLA_BOT_PRIVATE_KEY }}
+    
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          repository: 'dfinity/public-workflows'
+
+      - name: Python Setup
+        uses: ./.github/workflows/python-setup
+        
+      - name: Check Membership
+        id:  check-membership
+        run: python reusable_workflows/check_membership/check_membership.py
+        shell: bash
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_ORG: ${{ github.repository_owner }}
+          USER: ${{ github.event.pull_request.user.login }}
+
+  revoke-approvals:
+    name: Revoke Approvals
+    runs-on: ubuntu-latest
+    needs: check-membership
+    if: ${{ needs.check-membership.outputs.is_member != 'true' && needs.check-membership.result == 'success' }}
+    steps:
+      - name: Create GitHub App Token
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.PR_AUTOMATION_BOT_PUBLIC_APP_ID }}
+          private-key: ${{ secrets.PR_AUTOMATION_BOT_PUBLIC_PRIVATE_KEY }} # the PR Automation Bot has permissions to dismiss pull request reviews
+
+      - name: Dismiss Pull Request Reviews
+        run: |
+          #!/bin/bash
+          set -euo pipefail
+          reviews=$(curl -s -H "Authorization: token ${GH_TOKEN}" \
+            "https://api.github.com/repos/${GH_ORG}/${REPO}/pulls/${PULL_NUMBER}/reviews")
+
+          for review_id in $(echo "${reviews}" | jq -r '.[] | select(.state == "APPROVED") | .id'); do
+            curl -s -X PUT -H "Authorization: token ${GH_TOKEN}" \
+              -H "Accept: application/vnd.github.v3+json" \
+              -d '{"message": "Review dismissed by automation script."}' \
+              "https://api.github.com/repos/${GH_ORG}/${REPO}/pulls/${PULL_NUMBER}/reviews/${review_id}/dismissals"
+            echo "Dismissed review ${review_id}"
+          done
+        shell: bash
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_ORG: ${{ github.repository_owner }}
+          REPO: ${{ github.event.repository.name }}
+          PULL_NUMBER: ${{ github.event.pull_request.number }}          

--- a/.github/workflows/internal_vs_external.yml
+++ b/.github/workflows/internal_vs_external.yml
@@ -59,8 +59,8 @@ jobs:
         run: |
           #!/bin/bash
           set -euo pipefail
-          # Check if the token has access to the repository
-          curl -sS -f -I -H "Authorization: token ${GH_TOKEN}" https://api.github.com | grep -i x-oauth-scopes
+
+          gh auth status
 
           # reviews=$(curl -s -H "Authorization: token ${GH_TOKEN}" \
           #   "https://api.github.com/repos/${GH_ORG}/${REPO}/pulls/${PULL_NUMBER}/reviews")

--- a/.github/workflows/internal_vs_external.yml
+++ b/.github/workflows/internal_vs_external.yml
@@ -63,6 +63,12 @@ jobs:
           reviews=$(curl -s -H "Authorization: token ${GH_TOKEN}" \
             "https://api.github.com/repos/${GH_ORG}/${REPO}/pulls/${PULL_NUMBER}/reviews")
 
+          # Check if any reviews were found
+          if [ -z "$reviews" ] || [ "$reviews" == "[]" ]; then
+            echo "No reviews to dismiss"
+            exit 0
+          fi
+
           for review_id in $(echo "${reviews}" | jq -r '.[] | select(.state == "APPROVED") | .id'); do
             curl -s -X PUT -H "Authorization: token ${GH_TOKEN}" \
               -H "Accept: application/vnd.github.v3+json" \


### PR DESCRIPTION
The purpose of adding this workflow is to enable separate branch protection rules within the same repo. The logic works as follows:

- `for internal contributors`: keep default level 2 branch protection rules -> with every new push reviews are kept and only one additional review (not by the commit author) is required
- `for external contributors`: implement level 3 branch protection rules via this workflow -> with every new commit all PR reviews are cleared and the PR must be re-approved by all code owners

See the diagram below for the workflow logic:
![Pasted image 20250116132256](https://github.com/user-attachments/assets/9d5e7d2a-863d-48d9-a122-60b2b0fa9244)