### PR TITLE
feat(IDX): allow comments in repo list

### DIFF
--- a/reusable_workflows/check_membership/check_external_contrib.py
+++ b/reusable_workflows/check_membership/check_external_contrib.py
@@ -15,9 +15,8 @@ def get_repos_open_to_contributions(gh: github3.login) -> List[str]:
 
     file_content = download_gh_file(repo, file_path)
 
-    # convert .txt file to list
-    repo_list = file_content.split("\n")
-    repo_list.remove("")
+    # convert .txt file to list and strip out comments
+    repo_list = [line for line in file_content.split("\n") if line and not line.startswith("#")]
     return repo_list
 
 

--- a/reusable_workflows/check_membership/check_external_contrib.py
+++ b/reusable_workflows/check_membership/check_external_contrib.py
@@ -16,7 +16,7 @@ def get_repos_open_to_contributions(gh: github3.login) -> List[str]:
     file_content = download_gh_file(repo, file_path)
 
     # convert .txt file to list and strip out comments
-    repo_list = [line for line in file_content.split("\n") if line and not line.startswith("#")]
+    repo_list = [line.strip() for line in file_content.split("\n") if line.strip() and not line.strip().startswith("#")]
     return repo_list
 
 

--- a/reusable_workflows/check_membership/check_external_contrib.py
+++ b/reusable_workflows/check_membership/check_external_contrib.py
@@ -16,7 +16,7 @@ def get_repos_open_to_contributions(gh: github3.login) -> List[str]:
     file_content = download_gh_file(repo, file_path)
 
     # convert .txt file to list and strip out comments
-    repo_list = [line.strip() for line in file_content.split("\n") if line.strip() and not line.strip().startswith("#")]
+    repo_list = [line.split("#")[0].strip() for line in file_content.split("\n") if line.split("#")[0].strip()]
     return repo_list
 
 

--- a/reusable_workflows/tests/test_check_external_contrib.py
+++ b/reusable_workflows/tests/test_check_external_contrib.py
@@ -14,7 +14,10 @@ def test_check_repos_open_to_contributions():
     gh = mock.Mock()
     gh_repo = mock.Mock()
     file_contents = mock.Mock()
-    file_contents.decoded.decode.return_value = "one-repo\nanother-repo\n"
+    repo_list = open(
+        "reusable_workflows/tests/test_data/repo_list.txt", "r"
+    ).read()
+    file_contents.decoded.decode.return_value = repo_list
     gh_repo.file_contents.return_value = file_contents
     gh.repository.return_value = gh_repo
 

--- a/reusable_workflows/tests/test_check_external_contrib.py
+++ b/reusable_workflows/tests/test_check_external_contrib.py
@@ -23,7 +23,7 @@ def test_check_repos_open_to_contributions():
 
     repo_list = get_repos_open_to_contributions(gh)
 
-    assert repo_list == ["one-repo", "another-repo"]
+    assert repo_list == ["one-repo", "another-repo", "yet-another-repo"]
     gh.repository.assert_called_with(
         owner="dfinity", repository="repositories-open-to-contributions"
     )

--- a/reusable_workflows/tests/test_data/repo_list.txt
+++ b/reusable_workflows/tests/test_data/repo_list.txt
@@ -1,0 +1,2 @@
+one-repo
+another-repo # this comment should be ignored

--- a/reusable_workflows/tests/test_data/repo_list.txt
+++ b/reusable_workflows/tests/test_data/repo_list.txt
@@ -1,2 +1,3 @@
 one-repo
 another-repo # this comment should be ignored
+yet-another-repo

--- a/reusable_workflows/tests/test_data/repo_list.txt
+++ b/reusable_workflows/tests/test_data/repo_list.txt
@@ -1,3 +1,4 @@
 one-repo
 another-repo # this comment should be ignored
+# this comment should also be ignored
 yet-another-repo


### PR DESCRIPTION
This change allows comments in the https://github.com/dfinity/repositories-open-to-contributions/blob/master/open-repositories.txt file. When reading the file it ignores the comments.