### PR TITLE
chore(IDX): update trigger

### DIFF
--- a/.github/workflows/internal_vs_external.yml
+++ b/.github/workflows/internal_vs_external.yml
@@ -3,7 +3,7 @@
 name: Internal vs External Review
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - ready_for_review
       - synchronize


### PR DESCRIPTION
Switch to `pull_request_target` so workflow doesn't need manual approval.