### PR TITLE
chore(IDX): naming

### DIFF
--- a/.github/workflows/check_cla_ruleset.yml
+++ b/.github/workflows/check_cla_ruleset.yml
@@ -1,6 +1,6 @@
 # triggered on all repositories via rulesets
 
-name: CLA Check Ruleset
+name: Org CLA Check
 
 on:
   # because the cla workflow will run on worflows generated from forks, they do not have access to secrets

--- a/.github/workflows/check_cla_signed.yml
+++ b/.github/workflows/check_cla_signed.yml
@@ -1,6 +1,6 @@
 # Workflow to check if a user has correctly signed the CLA
 
-name: Check Issue Signed
+name: Org Issue Signed Check
 
 # this workflow is triggered from the repo https://github.com/dfinity/cla
 on:

--- a/.github/workflows/check_membership.yml
+++ b/.github/workflows/check_membership.yml
@@ -1,6 +1,6 @@
 # Workflow to check if a user is a member of the org
 
-name: Check Membership
+name: Org Membership Check
 
 on:
   workflow_call:

--- a/.github/workflows/internal_vs_external.yml
+++ b/.github/workflows/internal_vs_external.yml
@@ -1,6 +1,6 @@
 # Checks to see which reviews are required based on internal vs external contribution
 
-name: Internal vs External Review
+name: Org Internal-External Check
 
 on:
   pull_request_target:

--- a/.github/workflows/python_lint_test.yml
+++ b/.github/workflows/python_lint_test.yml
@@ -1,6 +1,6 @@
 # Workflow to run linting and tests on python code
 
-name: Python Workflow
+name: Org Python Tests
 
 on:
   pull_request:

--- a/.github/workflows/repo_policies.yml
+++ b/.github/workflows/repo_policies.yml
@@ -1,4 +1,4 @@
-name: Repository Policies
+name: Org Repository Policy
 
 on:
   workflow_call:

--- a/.github/workflows/repo_policies_ruleset.yml
+++ b/.github/workflows/repo_policies_ruleset.yml
@@ -1,6 +1,6 @@
 # triggered on all repositories via rulesets
 
-name: Repo Policies Ruleset
+name: Org Repo Policy Check
 
 on:
   pull_request_target:


### PR DESCRIPTION
We introduce "Org" prefix to improve visual look of actions tab so that we can more easily identify workflows that are part of org ruleset enforced to all public repos.