### PR TITLE
feat(IDX): leave comment if workflow fails

### DIFF
--- a/.github/workflows/check_external_files.yml
+++ b/.github/workflows/check_external_files.yml
@@ -52,6 +52,7 @@ jobs:
           export PYTHONPATH="$PWD/public-workflows/reusable_workflows/"
           python public-workflows/reusable_workflows/repo_policies/check_external_changes.py
         shell: bash
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }} # no actual token stored, read-only permissions
           ORG: ${{ github.repository_owner }}
@@ -59,3 +60,18 @@ jobs:
           MERGE_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           BRANCH_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           REPO_PATH: current-repo
+
+      - name: Add PR Comment
+        uses: actions/github-script@v7
+        if: ${{ steps.check-external-changes.conclusion == 'failure' }}
+        with:
+          script: |
+            let message = "Changes made to unallowed files."
+            message += 'Please see details here: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\n\n'
+
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: message
+            })

--- a/.github/workflows/check_external_files.yml
+++ b/.github/workflows/check_external_files.yml
@@ -5,9 +5,6 @@ name: Check Unallowed Changes
 
 on:
   pull_request_target:
-    types:
-      - ready_for_review
-      - synchronize
   merge_group: # merge group is always needed for a required workflows to prevent them from getting stuck, but we then skip it below
 
 permissions:


### PR DESCRIPTION
This leaves a comment on the PR if external contributors made a change to files they shouldn't. It makes it a little more explicit in case they don't immediately see the workflow failure.