### PR TITLE
fix(IDX): change workflow logic

### DIFF
--- a/.github/workflows/check_external_files.yml
+++ b/.github/workflows/check_external_files.yml
@@ -49,7 +49,6 @@ jobs:
           export PYTHONPATH="$PWD/public-workflows/reusable_workflows/"
           python public-workflows/reusable_workflows/repo_policies/check_external_changes.py
         shell: bash
-        continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }} # no actual token stored, read-only permissions
           ORG: ${{ github.repository_owner }}
@@ -60,7 +59,7 @@ jobs:
 
       - name: Add PR Comment
         uses: actions/github-script@v7
-        if: ${{ steps.check-external-changes.outcome == 'failure' }}
+        if: ${{ failure() }}
         with:
           script: |
             let message = "Changes made to unallowed files."


### PR DESCRIPTION
The problem with `continue-on-error` is that the workflow is marked as green, which is misleading. I want to try something else.