### PR TITLE
chore(IDX): update README, introduce git flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# internal-workflows
+# public-workflows
 
 This repository contains a set of internal workflows used at DFINITY. So far this includes:
 
@@ -17,3 +17,11 @@ Install pip-tools and run pip-compile:
 pip install pip-tools
 pip-compile requirements.in --upgrade
 ```
+
+## Testing and Releasing New Workflows
+
+Use the following steps to test and release new workflow changes:
+1. Merge changes to the `develop` branch
+1. If one doesn't already exist, set up a new testing workflow that gets applied to the `test-compliant-repository-public` and is pinned to the `develop` branch
+1. Test your changes there
+1. If the changes are successful, merge `develop` into `master`


### PR DESCRIPTION
This change introduces git flow, so that changes can first be tested on the `develop` branch before releasing to the production workflows.

For context, we previously tried merging directly to main, then creating new releases via tags, but this caused a lot of disruption for developers, as new tags caused old workflows to become "stuck" and needed to be re-triggered.