### PR TITLE
chore(IDX): add workflow_call back

### DIFF
--- a/.github/workflows/repo_policies.yml
+++ b/.github/workflows/repo_policies.yml
@@ -3,6 +3,7 @@ name: Bot Policies Ruleset
 on:
   pull_request_target:
   merge_group:
+  workflow_call:
 
 jobs:
   check-is-bot:


### PR DESCRIPTION
This is also called from the k8s repo, so we need to keep the `workflow_call` trigger.