### PR TITLE
chore(IDX): allow testing with droid-uexternal user

### DIFF
--- a/reusable_workflows/check_membership/check_membership.py
+++ b/reusable_workflows/check_membership/check_membership.py
@@ -13,6 +13,7 @@ APPROVED_BOT_LIST = [
     "pr-creation-bot-dfinity-ic[bot]",
     "pr-creation-bot-dfinity[bot]",
     "sa-github-api",
+    "droid-uexternal", # temporarily allow external user to contribute to repo not open to contributions for testing purposes
 ]
 
 


### PR DESCRIPTION
Temporarily allow 'droid-uexternal' bot to contribute for testing.