### PR TITLE
chore: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/check_cla_signed.yml
+++ b/.github/workflows/check_cla_signed.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
           repository: dfinity/public-workflows
       - name: Python Setup

--- a/.github/workflows/check_is_bot.yml
+++ b/.github/workflows/check_is_bot.yml
@@ -18,7 +18,7 @@ jobs:
       is_bot: ${{ steps.check-is-bot.outputs.is_bot}}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           repository: 'dfinity/public-workflows'
 

--- a/.github/workflows/internal_vs_external.yml
+++ b/.github/workflows/internal_vs_external.yml
@@ -92,7 +92,7 @@ jobs:
           EXTERNAL_CONTRIB_BLACKLIST_PATH: "repo/.github/repo_policies/EXTERNAL_CONTRIB_BLACKLIST"
 
       - name: Close PR
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         if: ${{ !cancelled() && steps.check_external_changes.conclusion == 'failure' }}
         with:
           script: |
@@ -117,14 +117,14 @@ jobs:
     if: github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository
     steps:
       - name: Create GitHub App Token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
         id: app-token
         with:
           app-id: ${{ vars.CLA_BOT_APP_ID }}
           private-key: ${{ secrets.CLA_BOT_PRIVATE_KEY }}
     
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           repository: 'dfinity/public-workflows'
 
@@ -157,7 +157,7 @@ jobs:
             — The DFINITY Foundation
 
       - name: Add Label
-        uses: actions/github-script@v6
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |
@@ -182,6 +182,6 @@ jobs:
           PR_ID: ${{ github.event.number }}
 
   check-repo-policies:
-    uses: dfinity/public-workflows/.github/workflows/repo_policies.yml@main
+    uses: dfinity/public-workflows/.github/workflows/repo_policies.yml@a947962e6f00131cda27070b41e8e3a629f051c6 # main
     secrets: inherit
     

--- a/.github/workflows/python_lint_test.yml
+++ b/.github/workflows/python_lint_test.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
 
     - name: Python Setup
       uses: ./.github/workflows/python-setup
@@ -30,7 +30,7 @@ jobs:
         flake8 reusable_workflows/
 
     - name: Create GitHub App Token
-      uses: actions/create-github-app-token@v1
+      uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
       id: app-token
       with:
         app-id: ${{ vars.CLA_BOT_APP_ID }}

--- a/.github/workflows/repo_policies.yml
+++ b/.github/workflows/repo_policies.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   check-is-bot:
-    uses: dfinity/public-workflows/.github/workflows/check_is_bot.yml@main
+    uses: dfinity/public-workflows/.github/workflows/check_is_bot.yml@a947962e6f00131cda27070b41e8e3a629f051c6 # main
     secrets: inherit
 
   check-bot-policies:
@@ -18,7 +18,7 @@ jobs:
     steps:
         # First check out code from public-workflows
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           repository: dfinity/public-workflows
           path: public-workflows


### PR DESCRIPTION
## Pin GitHub Actions to commit SHAs

GitHub Actions referenced by tag (e.g. `actions/checkout@v4`) use a mutable pointer — the tag owner can move it to a different commit at any time, including a malicious one. This is the attack vector used in the tj-actions/changed-files incident (CVE-2025-30066).

Pinning to a full 40-character commit SHA makes the reference immutable. The `# tag` comment preserves human readability so reviewers can tell which version is pinned.

Important: a SHA can also originate from a forked repository. A malicious actor can fork an action, push a compromised commit to the fork, and the SHA will resolve — but it won't exist in the upstream canonical repo. Each SHA in this PR was verified against the action's canonical repository (not a fork).

### Changes

- `actions/checkout@v3` -> `actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0`
  - Version: v3.6.0 | Latest: v6.0.2 | Release age: 89d
  - Commit: https://github.com/actions/checkout/commit/f43a0e5ff2bd294095638e18286ca9a3d1956744

- `actions/checkout@v4` -> `actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1`
  - Version: v4.3.1 | Latest: v6.0.2 | Release age: 89d
  - Commit: https://github.com/actions/checkout/commit/34e114876b0b11c390a56381ad16ebd13914f8d5

- `actions/github-script@v7` -> `actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0`
  - Version: v7.1.0 | Latest: v8 | Release age: 217d
  - Commit: https://github.com/actions/github-script/commit/f28e40c7f34bde8b3046d885e986cb6290c5673b

- `actions/create-github-app-token@v1` -> `actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0`
  - Version: v1.12.0 | Latest: v3.0.0 | Release age: 26d
  - Commit: https://github.com/actions/create-github-app-token/commit/d72941d797fd3113feb6b93fd0dec494b13a2547

- `actions/github-script@v6` -> `actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1`
  - Version: v6.4.1 | Latest: v8 | Release age: 217d
  - Commit: https://github.com/actions/github-script/commit/d7906e4ad0b1822421a7e6a35d5ca353c962f410

- `dfinity/public-workflows/.github/workflows/repo_policies.yml@main` -> `dfinity/public-workflows/.github/workflows/repo_policies.yml@a947962e6f00131cda27070b41e8e3a629f051c6 # main`
  - Version: main | Latest: ? | Release age: ?
  - Commit: https://github.com/dfinity/public-workflows/commit/a947962e6f00131cda27070b41e8e3a629f051c6

- `dfinity/public-workflows/.github/workflows/check_is_bot.yml@main` -> `dfinity/public-workflows/.github/workflows/check_is_bot.yml@a947962e6f00131cda27070b41e8e3a629f051c6 # main`
  - Version: main | Latest: ? | Release age: ?
  - Commit: https://github.com/dfinity/public-workflows/commit/a947962e6f00131cda27070b41e8e3a629f051c6


### Files modified

- `.github/workflows/check_cla_signed.yml`
- `.github/workflows/check_is_bot.yml`
- `.github/workflows/internal_vs_external.yml`
- `.github/workflows/python_lint_test.yml`
- `.github/workflows/repo_policies.yml`